### PR TITLE
【feature】トップページに最新10件のUMAを表示する

### DIFF
--- a/backend/controllers/cryptidController.mjs
+++ b/backend/controllers/cryptidController.mjs
@@ -56,8 +56,8 @@ export const getCryptidById = async (req, res, next) => {
     "_id name"
   ) || [];
 
-  console.log("--relatedUMAs--");
-  console.log(relatedUMAs);
+  // console.log("--relatedUMAs--");
+  // console.log(relatedUMAs);
 
   res.json({ ...cryptid.toObject(), related_uma: relatedUMAs });
 };

--- a/frontend/src/pages/Cryptid.jsx
+++ b/frontend/src/pages/Cryptid.jsx
@@ -57,6 +57,9 @@ const Cryptid = () => {
     <>
       <Section>
       <HeadPrimary>{cryptid ? `${cryptid.name}の情報` : "Loading..."}</HeadPrimary>
+      <p style={{ textAlign: 'right', fontSize: '80%' }}>
+        登録日：{new Date(cryptid.createdAt).toLocaleDateString()}
+      </p>
       </Section>
       <Section>
         <ProfileContainer>
@@ -124,7 +127,7 @@ const Cryptid = () => {
                   <iframe
                     src={videoUrl}
                     title={`${cryptid.name} Video ${index + 1}`}
-                    frameborder="0"
+                    frameBorder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                     referrerPolicy="strict-origin-when-cross-origin"
                     allowFullScreen

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from 'react-router-dom';
 import { AREA, SIZE } from "../constants";
 import { Section, PaddingBox } from "../components/layouts";
@@ -7,11 +7,17 @@ import { Card, CardContainer} from "../components/cards";
 import { HeadPrimary, HeadSecondary } from "../components/heads/Heading";
 import { InputText } from "../components/inputs";
 import TextWithIcon from "../components/TextWithIcon";
+import imageConfig from "../config/imageConfig";
 
 const Home = () => {
   const navigate = useNavigate();
   const [searchNameText, setSearchNameText] = useState("");
   const [isComposing, setIsComposing] = useState(false);
+
+  const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
+  const [ latestCryptids, setLatestCryptids ] = useState([]); 
+  const [ error, setError ] = useState(null);
+  const imageUrl = imageConfig.imageUrl;
 
   // エリアボタンクリック
   const handleAreaButtonClick = (area) => {
@@ -31,8 +37,29 @@ const Home = () => {
     if (event.key === "Enter" && !isComposing) {
       navigate(`/cryptids?name=${encodeURIComponent(searchNameText)}`);
     }
-    
   }
+
+  useEffect(() => {
+      const fetchLatestCryptids = async () => {
+        try {
+
+          //最新10件
+          const response = await fetch(`${API_BASE_URL}/cryptids?limit=10&sort=-createdAt`);
+  
+          if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+          }
+  
+          const data = await response.json();
+          setLatestCryptids(data);
+        } catch (error) {
+          console.error("Error fetching latest cryptids:", error);
+          setError("データの取得に失敗しました。");
+        }
+      };
+  
+      fetchLatestCryptids();
+    }, []);
 
   return (
     <>
@@ -42,19 +69,24 @@ const Home = () => {
       <Section>
         <h4>世界中のUMA情報を集めたデータベース</h4>
       </Section>
-      {/* <Section>
+      <Section>
+        {error ? <p style={{ color: "red" }}>{error}</p> : null}
         <HeadSecondary>
           <TextWithIcon iconSrc="image/i-green-issie.svg" alt="イッシーアイコン">最近追加されたUMA</TextWithIcon>
         </HeadSecondary>
         <CardContainer>
-          <Card 
-            imageSrc="image/flogman.jpeg"
-            title="カードのタイトル"
-            description="これはカードの説明文です。詳細な情報をここに記載します"
-            isNew={true}
-          />
+          {latestCryptids.map((cryptid) => (
+            <Card
+              key={cryptid._id}
+              imageSrc={`${imageUrl}/${cryptid.id}/thumbnail.jpeg`}
+              title={cryptid.name}
+              description={`${cryptid.description.slice(0, 40)}...`}
+              isNew={true}
+              to={`/cryptids/${cryptid._id}`}
+              />
+          ))}
         </CardContainer>
-      </Section> */}
+      </Section>
       <Section>
         <HeadSecondary>
           <TextWithIcon iconSrc="image/i-green-glass.svg" alt="虫めがねアイコン">目撃エリアから探す</TextWithIcon>


### PR DESCRIPTION
この機能追加に伴い、行った主な修正

【バックエンド側】
・パラメータクエリはname, size, areaのいずれか１つを受け付ける仕様だったが、その制限を削除
・パラメータが何もない状態でもcryptidsを返すよう変更（件数制限は課す）
・sortパラメータを追加して、並び替えを指定可能にした
・limit, pageパラメータを追加して、返却する件数やページ数を指定可能にした

【フロントエンド側】
・Cardコンポーネントにて最新10件を表示するようにした

