### PR TITLE
【fix】ページをリロード（F5）すると「404 Not Found」エラーが発生する問題の修正 v2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "uma-front",
   "version": "0.1.0",
   "private": true,
-  "homepage": ".",
+  "homepage": "/",
   "dependencies": {
     "cra-template": "1.2.0",
     "normalize.css": "^8.0.1",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>UMA-DB</title>
+    <base href="/" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
issue
https://github.com/simazo/UMA-DB/issues/21

１つ前の修正は不要だったので、
https://github.com/simazo/UMA-DB/pull/29

今回のPRで

１，nginxの設定は以下のように元に戻して、

```
server {
    listen 80;
    server_name api.uma-db.com;

    # HTTPからHTTPSへのリダイレクト設定
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name api.uma-db.com;

    # SSL証明書の設定（Certbotで取得した証明書パス）
    ssl_certificate /etc/letsencrypt/live/api.uma-db.com/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/api.uma-db.com/privkey.pem;

    # SSLの設定（推奨）
    ssl_protocols TLSv1.2 TLSv1.3;
    ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384';
    ssl_prefer_server_ciphers off;

    location / {
        proxy_pass http://localhost:8080;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection 'upgrade';
        proxy_set_header Host $host;
        proxy_cache_bypass $http_upgrade;
    }
}

```


２．ReactのサーバであるRenderでRewirteを設定し、

<img width="1056" alt="スクリーンショット 2025-03-10 20 11 08" src="https://github.com/user-attachments/assets/c36b8cae-40c9-4c4b-bd38-fee8121b411f" />



３．headタグに以下を追加した

`<base href="/" />`