### PR TITLE
【feature】トップページに登録済みのUMA総件数を表示する

### DIFF
--- a/backend/controllers/cryptidController.mjs
+++ b/backend/controllers/cryptidController.mjs
@@ -48,22 +48,37 @@ export const getCryptids = async (req, res, next) => {
 };
 
 export const getCryptidById = async (req, res, next) => {
-  const cryptid = await Cryptid.findById(req.params.id);
+  try {
+    const cryptid = await Cryptid.findById(req.params.id);
   
-  if (cryptid === null) {
-    const error = new Error("Cryptid Not Found");
-    error.status = 404;
-    return next(error);
+    if (cryptid === null) {
+      const error = new Error("Cryptid Not Found");
+      error.status = 404;
+      return next(error);
+    }
+  
+    // 関連するUMAのデータを_idとnameだけ取得
+    const relatedUMAs = await Cryptid.find(
+      { id: { $in: cryptid.related_uma } }, 
+      "_id name"
+    ) || [];
+  
+    // console.log("--relatedUMAs--");
+    // console.log(relatedUMAs);
+  
+    res.json({ ...cryptid.toObject(), related_uma: relatedUMAs });
+  } catch(error) {
+    console.log(`Error occurred:${error}`);
+    next(error);
   }
+};
 
-  // 関連するUMAのデータを_idとnameだけ取得
-  const relatedUMAs = await Cryptid.find(
-    { id: { $in: cryptid.related_uma } }, 
-    "_id name"
-  ) || [];
-
-  // console.log("--relatedUMAs--");
-  // console.log(relatedUMAs);
-
-  res.json({ ...cryptid.toObject(), related_uma: relatedUMAs });
+export const getCryptidCount = async (req, res, next) => {
+  try {
+    const count = await Cryptid.countDocuments();
+    res.json({ count });
+  } catch (error) {
+    console.log(`Error occurred:${error}`);
+    next(error);
+  }
 };

--- a/backend/routes/cryptidRoutes.mjs
+++ b/backend/routes/cryptidRoutes.mjs
@@ -4,12 +4,16 @@ import { requestErrorHandler } from "../helpers/request-handler.mjs";
 import {
   getCryptids,
   getCryptidById,
+  getCryptidCount,
 } from "../controllers/cryptidController.mjs";
 
 const router = express.Router();
 
-router.get("/", requestErrorHandler(getCryptids));
+router.get("/count", requestErrorHandler(getCryptidCount));
 
 router.get("/:id", requestErrorHandler(getCryptidById));
+
+router.get("/", requestErrorHandler(getCryptids));
+
 
 export default router;

--- a/frontend/mockup/index.html
+++ b/frontend/mockup/index.html
@@ -21,7 +21,7 @@
       </h1>
     </div>
     <div class="section">
-      <h4>世界中のUMA情報を集めたデータベース</h4>
+      <h4>世界中のUMA情報を集めたデータベース <span style="font-size: 120%;">【現在345件】</span> </h4>
     </div>
     <div class="section">
       <h2 class="head-secondary text-with-icon">

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -11,11 +11,12 @@ import imageConfig from "../config/imageConfig";
 
 const Home = () => {
   const navigate = useNavigate();
-  const [searchNameText, setSearchNameText] = useState("");
-  const [isComposing, setIsComposing] = useState(false);
+  const [ searchNameText, setSearchNameText ] = useState("");
+  const [ isComposing, setIsComposing ] = useState(false);
 
   const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
-  const [ latestCryptids, setLatestCryptids ] = useState([]); 
+  const [ latestCryptids, setLatestCryptids ] = useState([]);
+  const [ count, setCount ] = useState([null]);
   const [ error, setError ] = useState(null);
   const imageUrl = imageConfig.imageUrl;
 
@@ -42,14 +43,11 @@ const Home = () => {
   useEffect(() => {
     const fetchLatestCryptids = async () => {
       try {
-
         //最新10件
         const response = await fetch(`${API_BASE_URL}/cryptids?limit=4&sort=-createdAt`);
-
         if (!response.ok) {
           throw new Error(`HTTP error! Status: ${response.status}`);
         }
-
         const data = await response.json();
         setLatestCryptids(data.cryptids);
       } catch (error) {
@@ -58,7 +56,21 @@ const Home = () => {
       }
     };
 
+    const fetchDataCount = async () => {
+      try {
+        const response = await fetch(`${API_BASE_URL}/cryptids/count`);
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        const data = await response.json();
+        setCount(data.count); // データ件数の状態更新
+      } catch (error) {
+        console.error("Error fetching data count:", error);
+      }
+    };
+
     fetchLatestCryptids();
+    fetchDataCount();
   }, []);
 
   return (
@@ -67,7 +79,7 @@ const Home = () => {
         <HeadPrimary>UMA-DB</HeadPrimary>
       </Section>
       <Section>
-        <h4>世界中のUMA情報を集めたデータベース</h4>
+        <h4>世界中のUMA情報を集めたデータベース 【現在:<span style={{ fontSize: "120%" }}>{count}</span>件】</h4>
       </Section>
       <Section>
         {error ? <p style={{ color: "red" }}>{error}</p> : null}


### PR DESCRIPTION
issue
https://github.com/simazo/UMA-DB/issues/25

カウント数を返す以下のルーティングを追加したが、
"/count"

Cryptid詳細のルーティングとバッティングするため
"/:id"

ルーティングの順序を以下のようにした
"/count"
"/:id"
