### PR TITLE
【feature】OGP設定の修正

### DIFF
--- a/backend/controllers/cryptidController.mjs
+++ b/backend/controllers/cryptidController.mjs
@@ -70,6 +70,14 @@ export const getCryptidById = async (req, res, next) => {
   
     // console.log("--relatedUMAs--");
     // console.log(relatedUMAs);
+
+    const ua = req.headers["user-agent"];
+    const isBot = /twitterbot|facebookexternalhit|Slackbot|Discordbot|Pinterest/.test(ua);
+
+    if (isBot) {
+      const html = generateOgpHtml({ ...cryptid.toObject(), related_uma: relatedUMAs });
+      return res.set("Content-Type", "text/html").send(html);
+    }
   
     res.json({ ...cryptid.toObject(), related_uma: relatedUMAs });
   } catch(error) {

--- a/frontend/src/pages/Cryptid/CryptidView.jsx
+++ b/frontend/src/pages/Cryptid/CryptidView.jsx
@@ -9,11 +9,9 @@ import {
   RightColumn,
 } from "../../components/layouts/ProfileContainer";
 
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
-
 const CryptidView = ({cryptid}) => {
   const tweetText = `${cryptid.name}に関する情報はこちら`;
-  const ogpUrl = `${API_BASE_URL}/ogp/${cryptid._id}`;
+  const ogpUrl = `https://uma-db.com/cryptids/${cryptid._id}`;
   const hashtags = ["UMA", "未確認生物", cryptid.name, ...(cryptid.alias ? [cryptid.alias] : [])];
 
   return (


### PR DESCRIPTION
<meta property="og:url" >
や
<meta name="twitter:url">
にuma−db.com/cryptids/を設定しているのに、
ツイートで共有しているURL: api.uma-db.com/ogpが優先されてしまっている。

そのため、ユーザがクリックすると意図したURLにならない。

ボット時だけOGP設定を返すよう修正